### PR TITLE
StringFUnctions

### DIFF
--- a/Traits/StringFunctions.php
+++ b/Traits/StringFunctions.php
@@ -2,7 +2,7 @@
 
 namespace ConsoleTVs\Support\Traits;
 
-trait StringFUnctions
+trait StringFunctions
 {
     /**
      * Get a string between two substrings.


### PR DESCRIPTION
composer 2
Class ConsoleTVs\Support\Traits\StringFUnctions located in ./vendor/consoletvs/support/Traits/StringFunctions.php does not comply with psr-4 autoloading standard. Skipping.